### PR TITLE
Fix memory issues reported by clang static analyzer

### DIFF
--- a/src/modules/module-flatpak.c
+++ b/src/modules/module-flatpak.c
@@ -778,6 +778,7 @@ static bool module_init(struct pw_module *module, struct pw_properties *properti
 	return true;
 
       error:
+	free(impl);
 	pw_log_error("Failed to connect to system bus: %s", error.message);
 	dbus_error_free(&error);
 	return false;

--- a/src/modules/spa/spa-monitor.c
+++ b/src/modules/spa/spa-monitor.c
@@ -272,7 +272,6 @@ struct pw_spa_monitor *pw_spa_monitor_load(struct pw_core *core,
 		goto init_failed;
 	}
 	if ((res = spa_handle_get_interface(handle, t->spa_monitor, &iface)) < 0) {
-		free(handle);
 		pw_log_error("can't get MONITOR interface: %d", res);
 		goto interface_failed;
 	}

--- a/src/pipewire/rtkit.c
+++ b/src/pipewire/rtkit.c
@@ -77,6 +77,7 @@ struct pw_rtkit_bus *pw_rtkit_bus_get_system(void)
 	return bus;
 
       error:
+	free(bus);
 	pw_log_error("Failed to connect to system bus: %s", error.message);
 	dbus_error_free(&error);
 	return NULL;


### PR DESCRIPTION
Clang static analyzer reported couple of memory leaks and a user after free issue. This pull request fixes them. Each commit fixes one issue.