### PR TITLE
Fix clang warnings about comparing uint32 < 0

### DIFF
--- a/spa/plugins/alsa/alsa-monitor.c
+++ b/spa/plugins/alsa/alsa-monitor.c
@@ -548,7 +548,7 @@ impl_enum_interface_info(const struct spa_handle_factory *factory,
 	spa_return_val_if_fail(factory != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 	spa_return_val_if_fail(info != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 
-	if (index < 0 || index >= SPA_N_ELEMENTS(impl_interfaces))
+	if (index >= SPA_N_ELEMENTS(impl_interfaces))
 		return SPA_RESULT_ENUM_END;
 
 	*info = &impl_interfaces[index];

--- a/spa/plugins/alsa/alsa-source.c
+++ b/spa/plugins/alsa/alsa-source.c
@@ -741,7 +741,7 @@ impl_enum_interface_info(const struct spa_handle_factory *factory,
 	spa_return_val_if_fail(factory != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 	spa_return_val_if_fail(info != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 
-	if (index < 0 || index >= SPA_N_ELEMENTS(impl_interfaces))
+	if (index >= SPA_N_ELEMENTS(impl_interfaces))
 		return SPA_RESULT_ENUM_END;
 
 	*info = &impl_interfaces[index];

--- a/spa/plugins/v4l2/v4l2-monitor.c
+++ b/spa/plugins/v4l2/v4l2-monitor.c
@@ -415,7 +415,7 @@ impl_enum_interface_info(const struct spa_handle_factory *factory,
 	spa_return_val_if_fail(factory != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 	spa_return_val_if_fail(info != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 
-	if (index < 0 || index >= SPA_N_ELEMENTS(impl_interfaces))
+	if (index >= SPA_N_ELEMENTS(impl_interfaces))
 		return SPA_RESULT_ENUM_END;
 
 	*info = &impl_interfaces[index];

--- a/spa/plugins/v4l2/v4l2-source.c
+++ b/spa/plugins/v4l2/v4l2-source.c
@@ -985,7 +985,7 @@ static int impl_enum_interface_info(const struct spa_handle_factory *factory,
 	spa_return_val_if_fail(factory != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 	spa_return_val_if_fail(info != NULL, SPA_RESULT_INVALID_ARGUMENTS);
 
-	if (index < 0 || index >= SPA_N_ELEMENTS(impl_interfaces))
+	if (index >= SPA_N_ELEMENTS(impl_interfaces))
 		return SPA_RESULT_ENUM_END;
 
 	*info = &impl_interfaces[index];

--- a/src/modules/module-jack.c
+++ b/src/modules/module-jack.c
@@ -989,7 +989,7 @@ connection_data(void *data, int fd, enum spa_io mask)
 	struct client *client = data;
 
 	if (mask & (SPA_IO_ERR | SPA_IO_HUP)) {
-		pw_log_error("protocol-native %p: got connection error", client->impl);
+		pw_log_error("jack %p: got connection error", client->impl);
 		client_killed(client);
 		return;
 	}

--- a/src/modules/module-protocol-native/connection.c
+++ b/src/modules/module-protocol-native/connection.c
@@ -75,7 +75,7 @@ int pw_protocol_native_connection_get_fd(struct pw_protocol_native_connection *c
 {
 	struct impl *impl = SPA_CONTAINER_OF(conn, struct impl, this);
 
-	if (index < 0 || index >= impl->in.n_fds)
+	if (index >= impl->in.n_fds)
 		return -1;
 
 	return impl->in.fds[index];


### PR DESCRIPTION
clangs complains about an uint32 compared to < 0:
warning: comparison of unsigned expression < 0 is always false [-Wtautological-compare]

So remove these comparisos and an uint32 never will be less than 0.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>