### PR TITLE
spa/include/meson: Install hook.h

### DIFF
--- a/spa/include/spa/meson.build
+++ b/spa/include/spa/meson.build
@@ -10,6 +10,7 @@ spa_headers = [
   'format.h',
   'format-builder.h',
   'format-utils.h',
+  'hook.h',
   'list.h',
   'log.h',
   'loop.h',


### PR DESCRIPTION
When compiling some application and include spa/loop.h, it needs hook.h,
so install it.

Signed-off-by: Marcos Paulo de Souza <marcos.souza.org@gmail.com>